### PR TITLE
Fix rendering of tables

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ from recommonmark.transform import AutoStructify
 # -- Project information -----------------------------------------------------
 
 project = 'Uwazi'
-copyright = '2020, HURIDOCS'
+copyright = '2024, HURIDOCS'
 author = 'HURIDOCS'
 
 
@@ -33,7 +33,8 @@ author = 'HURIDOCS'
 
 extensions = [
     'recommonmark',
-    'sphinx_rtd_theme'
+    'sphinx_rtd_theme',
+    'sphinx_markdown_tables'
 ]
 
 master_doc = 'index'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx<7.0.0
 recommonmark
 sphinx_rtd_theme
+sphinx_markdown_tables


### PR DESCRIPTION
Sphinx supports markdown via Recommonmark, which does not support tables. Adding the extension sphinx-markdown-tables provides support for markdown tables. [[Source](https://pypi.org/project/sphinx-markdown-tables/)]

**Before**

![Tables-before](https://github.com/huridocs/uwazi-documentation/assets/102693686/151cf2ec-7bda-4d17-a186-27ac025d2e6c)


**After**
![Table-after](https://github.com/huridocs/uwazi-documentation/assets/102693686/d95b3288-234b-4951-ac2f-2f2b2813ed62)
