### PR TITLE
Add Attention - Login username

### DIFF
--- a/admin-docs/managing-settings.md
+++ b/admin-docs/managing-settings.md
@@ -6,6 +6,10 @@
 
 Step 1: Log into your instance.
 
+:::{attention}
+Add your username, which is not the same as your registered email address.
+:::
+
 Step 2: Navigate to the **Settings** ![Settings icon](images/cog-solid.png) area and click **Account**.
 
 Step 3: You can change your email address here, as well as your account password.


### PR DESCRIPTION
Use case: There is often a confusion about what a 'User' field in login stage is, which is the username. Users often understand 'User' field to mean adding their email address.